### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Please note that this version breaks compatibility with all V0.X.X.
 * [Julian Traversa](https://github.com/JTraversa)
 * [Tianyu](https://github.com/Tianyu00)
 * [Salient](https://github.com/Salient)
-* [mm0](https://github.com/mm0)
+* [Matt Margolin](https://github.com/mm0)
 
 Message me on Github or [send an email](mailto:alienbrett648@gmail.com) if you enjoyed the project or thought it could be improved. I do my best to code with quality but sometimes it is easier said than done. Anyone with an interest with an eye for detail is welcome to contribute.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Please note that this version breaks compatibility with all V0.X.X.
 * [Julian Traversa](https://github.com/JTraversa)
 * [Tianyu](https://github.com/Tianyu00)
 * [Salient](https://github.com/Salient)
+* [mm0](https://github.com/mm0)
 
 Message me on Github or [send an email](mailto:alienbrett648@gmail.com) if you enjoyed the project or thought it could be improved. I do my best to code with quality but sometimes it is easier said than done. Anyone with an interest with an eye for detail is welcome to contribute.
 

--- a/docs/installing.html
+++ b/docs/installing.html
@@ -219,7 +219,7 @@ Place the API keys into a JSON file (this looks very similar to a python dict):<
     <span class="s1">&#39;ALLY_CONSUMER_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
     <span class="s1">&#39;ALLY_CONSUMER_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
     <span class="s1">&#39;ALLY_OAUTH_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_OAUTH_TOKEN</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_OAUTH_TOKEN&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
     <span class="s1">&#39;ALLY_ACCOUNT_NBR&#39;</span><span class="p">:</span><span class="n">XXXX</span>
 <span class="p">}</span>
 </pre></div>

--- a/docs/installing.html
+++ b/docs/installing.html
@@ -216,10 +216,10 @@ instantiation is easy:</p>
 this is about as secure as the environment variable method.
 Place the API keys into a JSON file (this looks very similar to a python dict):</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="p">{</span>
-    <span class="s1">&#39;ALLY_RESOURCE_OWNER_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_RESOURCE_OWNER_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_CLIENT_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_CLIENT_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_CONSUMER_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_CONSUMER_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_OAUTH_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_OAUTH_TOKEN</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
     <span class="s1">&#39;ALLY_ACCOUNT_NBR&#39;</span><span class="p">:</span><span class="n">XXXX</span>
 <span class="p">}</span>
 </pre></div>
@@ -235,10 +235,10 @@ Place the API keys into a JSON file (this looks very similar to a python dict):<
 Keep in mind that this is much less secure for distributable applications, since anyone with these keys
 will have access to the account with which they’re associated.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">params</span> <span class="o">=</span> <span class="p">{</span>
-    <span class="s1">&#39;ALLY_RESOURCE_OWNER_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_RESOURCE_OWNER_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_CLIENT_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
-    <span class="s1">&#39;ALLY_CLIENT_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_CONSUMER_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_CONSUMER_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_OAUTH_SECRET&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
+    <span class="s1">&#39;ALLY_OAUTH_KEY&#39;</span><span class="p">:</span><span class="n">XXXX</span><span class="p">,</span>
     <span class="s1">&#39;ALLY_ACCOUNT_NBR&#39;</span><span class="p">:</span><span class="n">XXXX</span>
 <span class="p">}</span>
 <span class="n">a</span> <span class="o">=</span> <span class="n">ally</span><span class="o">.</span><span class="n">Ally</span><span class="p">(</span><span class="n">params</span><span class="p">)</span>

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -29,7 +29,7 @@ Contents
    maintaining
 
 
-Version 1.0.6
+Version 1.0.7
 ----------------
 
 The lastest redesign preserves many features of the old interface, and incorporates a few new ones.
@@ -85,6 +85,8 @@ If you're dying to buy me a beer, I accept venmo at @alienbrett. That said, feel
 .. _`Salient`: https://github.com/Salient
 
 .. _`Tianyu`: https://github.com/Tianyu00
+
+.. _`mm0`: https://github.com/mm0
 
 .. _`send me an email`: mailto:alienbrett648@gmail.com
 

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -86,7 +86,7 @@ If you're dying to buy me a beer, I accept venmo at @alienbrett. That said, feel
 
 .. _`Tianyu`: https://github.com/Tianyu00
 
-.. _`mm0`: https://github.com/mm0
+.. _`Matt Margolin`: https://github.com/mm0
 
 .. _`send me an email`: mailto:alienbrett648@gmail.com
 

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -29,7 +29,7 @@ Contents
    maintaining
 
 
-Version 1.0.7
+Version 1.0.6
 ----------------
 
 The lastest redesign preserves many features of the old interface, and incorporates a few new ones.


### PR DESCRIPTION
When providing the API keys directly to the Ally class, the dictionary keys specified in the documentation do not work. This updates the documentation with the correct keys.  I have not bumped the version number since it is just a documentation change, but please let me know if you would like me to do so.  I have just found this project and find it to be one of the better Ally Invest Python packages, although it is missing two of the API features I am most interested in using (news, option search). I would like to contribute to the implementation of these additional features as well.