### PR TITLE
cicd(lint): Update linter (black) GHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v3
       - name: Lint (black)
         uses: psf/black@stable
         with:
-          args: "./ally --check"
-
+          options: "--check --verbose"
+          src: "./ally"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install tools


### PR DESCRIPTION
Updated linter GHA code as per latest docs: https://black.readthedocs.io/en/stable/integrations/github_actions.html